### PR TITLE
allow job submission to PR as SA

### DIFF
--- a/block_cascade/cli/crud.py
+++ b/block_cascade/cli/crud.py
@@ -4,6 +4,7 @@ from typing import Optional
 import click
 import json
 from google.cloud import aiplatform_v1beta1 as aiplatform
+from google.cloud.aiplatform_v1beta1 import ServiceAccountSpec, ResourceRuntimeSpec
 from google.protobuf import json_format
 
 from block_cascade import GcpResource
@@ -26,6 +27,11 @@ def get_gcp_region(config: dict) -> str:
 
 def get_persistent_resource_payload(resource: GcpResource) -> dict:
     """Generate a persistent resource payload from a GcpResource."""
+
+    # service account spec
+    resource_runtime_spec = ResourceRuntimeSpec(
+        service_account_spec=ServiceAccountSpec(enable_custom_service_account=True)
+    )
 
     cpu_machine_type = resource.chief.type
     cpu_replica_count = resource.chief.count
@@ -82,6 +88,7 @@ def get_persistent_resource_payload(resource: GcpResource) -> dict:
     persistent_resource = {
         "display_name": resource.persistent_resource_id,
         "resource_pools": RESOURCE_POOLS,
+        "resource_runtime_spec": resource_runtime_spec,
     }
 
     return persistent_resource

--- a/block_cascade/executors/vertex/job.py
+++ b/block_cascade/executors/vertex/job.py
@@ -1,6 +1,7 @@
 """
 Data model for running jobs on VertexAI
 """
+
 from dataclasses import asdict, dataclass
 import os
 from typing import List, Mapping, Optional, Union
@@ -118,10 +119,7 @@ class VertexJob:
         if environment.network is not None:
             job_spec["network"] = environment.network
 
-        if (
-            environment.service_account is not None
-            and self.resource.persistent_resource_id is None
-        ):
+        if environment.service_account is not None:
             job_spec["service_account"] = environment.service_account
 
         if self.dashboard is True:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "block-cascade"
 packages = [
     {include = "block_cascade"}
 ]
-version = "2.4.2"
+version = "2.4.3"
 description = "Library for model training in multi-cloud environment."
 readme = "README.md"
 authors = ["Block"]


### PR DESCRIPTION
Updates the `get_persistent_resource_payload` to create persistent resources that allow for job submission by users acting as custom service accounts. 