### PR TITLE
fixes type error bug from base module cannot be inferred

### DIFF
--- a/block_cascade/decorators.py
+++ b/block_cascade/decorators.py
@@ -233,7 +233,7 @@ def remote(
             if resource.cloud_pickle_infer_base_module:
                 base_module_name = _infer_base_module(func)
                 # if base module is __main__ or None, it can't be registered
-                if base_module_name.startswith("__") or base_module_name is None:
+                if base_module_name is None or base_module_name.startswith("__"):
                     prefect_logger.warn(failed_to_infer_base)
                 else:
                     resource.cloud_pickle_by_value.append(base_module_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "block-cascade"
 packages = [
     {include = "block_cascade"}
 ]
-version = "2.4.4"
+version = "2.4.5"
 description = "Library for model training in multi-cloud environment."
 readme = "README.md"
 authors = ["Block"]


### PR DESCRIPTION
When the base module can not be inferred for Databricks job, `_infer_base_module` will return None. Changed the if statement in `decorators.remote` to short circuit and avoid throwing an error. 