### PR TITLE
Allow Project to Be Optional

### DIFF
--- a/block_cascade/executors/vertex/resource.py
+++ b/block_cascade/executors/vertex/resource.py
@@ -79,7 +79,7 @@ class GcpEnvironmentConfig:
     Description of the specific GCP environment in which a job will run.
     A valid project and service account are required.
 
-    project: str
+    project: Optional[str]
         GCP Project used to launch job.
     storage_location: Optional[str]
         Path to the directory on GCS where files will be staged and output written
@@ -95,16 +95,12 @@ class GcpEnvironmentConfig:
         the project name in the container registry URL.
     """
 
-    project: str
+    project: Optional[str] = None
     storage_location: Optional[str] = None
     service_account: Optional[str] = None
     region: Optional[str] = None
     network: Optional[str] = None
     image: Optional[str] = None
-
-    def __post_init__(self):
-        if self.storage_location is None:
-            self.storage_location = f"gs://cascade-{self.project}/"
 
     @classmethod
     def with_shared_vpc(cls: T, **kwargs) -> Type[T]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "block-cascade"
 packages = [
     {include = "block_cascade"}
 ]
-version = "2.4.6"
+version = "2.5.0"
 description = "Library for model training in multi-cloud environment."
 readme = "README.md"
 authors = ["Block"]


### PR DESCRIPTION
Prior behavior allowed `project` to be `Optional` such that it can be inferred from VM Metadata server if running from GCP Compute Engine.

This forces the removal of the `__post_init__` which utilizes the provide project.  Personally , I find `__post_init__` can be an anti pattern when setting values because it does not align with the typing on the data model (e.g. `Optional` in the definition but it will never be `Optional` if `__post_init__` sets the value).   Instead, callers should just provide the bucket they want to use (so it's clear also without having to look through the source code for the computed value).