### PR TITLE
Allow Timeout Seconds for Databricks Job to Be Configurable Via Resource

### DIFF
--- a/block_cascade/executors/databricks/executor.py
+++ b/block_cascade/executors/databricks/executor.py
@@ -241,6 +241,7 @@ class DatabricksExecutor(Executor):
                 self.cluster_policy
             ),
             run_path=self.run_path,
+            timeout_seconds=self.resource.timeout_seconds,
         )
 
     def _run(self):

--- a/block_cascade/executors/databricks/job.py
+++ b/block_cascade/executors/databricks/job.py
@@ -46,7 +46,7 @@ class DatabricksJob:
     run_path: str
     cluster_policy_id: str
     existing_cluster_id: Optional[str] = None
-    timeout_seconds: str = 86400
+    timeout_seconds: int = 86400
 
     def create_payload(self):
         """"""

--- a/block_cascade/executors/databricks/resource.py
+++ b/block_cascade/executors/databricks/resource.py
@@ -98,6 +98,8 @@ class DatabricksResource:
     python_libraries: Optional[List[str]] = None
         If provided, install these additional libraries on the cluster when the
         remote task is run
+    timeout_seconds: int = 86400
+        The maximum time this job can run for; default is 24 hours.
 
     """  # noqa: E501
 
@@ -117,6 +119,7 @@ class DatabricksResource:
     cloud_pickle_infer_base_module: Optional[bool] = True
     task_args: Optional[dict] = None
     python_libraries: Optional[List[str]] = None
+    timeout_seconds: int = 86400
 
     def __post_init__(self):
         if self.group_name is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "block-cascade"
 packages = [
     {include = "block_cascade"}
 ]
-version = "2.5.2"
+version = "2.5.3"
 description = "Library for model training in multi-cloud environment."
 readme = "README.md"
 authors = ["Block"]


### PR DESCRIPTION
Exposes a `timeout_seconds` argument on the `DatabricksResource` to be forwarded to the actual job payload creation.