### PR TITLE
local resource override

### DIFF
--- a/block_cascade/decorators.py
+++ b/block_cascade/decorators.py
@@ -145,7 +145,7 @@ def remote(
         task_id = get_from_prefect_context("task_run_id", "LOCAL")
         task_name = get_from_prefect_context("task_run", "LOCAL")
 
-        via_cloud = is_prefect_cloud_deployment()  # always True in tests if set via the method
+        via_cloud = is_prefect_cloud_deployment()
         prefect_logger.info(f"Via cloud? {via_cloud}")
 
         # create a new wrapped partial function with the passed *args and **kwargs

--- a/block_cascade/decorators.py
+++ b/block_cascade/decorators.py
@@ -32,6 +32,7 @@ def remote(
     web_console_access: Optional[bool] = False,
     tune: Optional[Tune] = None,
     code_package: Optional[Path] = None,
+    no_resource_on_local: bool = False,
     *args,
     **kwargs,
 ):
@@ -147,6 +148,11 @@ def remote(
         # create a new wrapped partial function with the passed *args and **kwargs
         # so that it can be sent to the remote executor with its parameters
         packed_func = wrapped_partial(func, *args, **kwargs)
+
+        # if running a flow locally ignore the remote resource, even if specified
+        # necessary for running a @remote decorated task in a local flow
+        if not via_cloud and no_resource_on_local:
+            resource = None
 
         # if no resource is passed, run locally
         if resource is None:

--- a/block_cascade/decorators.py
+++ b/block_cascade/decorators.py
@@ -85,7 +85,6 @@ def remote(
     no_resource_on_local: bool
         If true, set resource to None when running a Prefect flow locally
     """
-
     if not resource:
         resource_configurations = find_default_configuration() or {}
         if config_name:
@@ -110,6 +109,7 @@ def remote(
             resource=resource,
             tune=tune,
             code_package=code_package,
+            no_resource_on_local=no_resource_on_local,
             *args,
             **kwargs,
         )
@@ -134,6 +134,7 @@ def remote(
         tune = remote_args.get("tune", None)
         code_package = remote_args.get("code_package", None)
         web_console_access = remote_args.get("web_console_access", False)
+        no_resource_on_local = remote_args.get('no_resource_on_local', False)
 
         # get the prefect logger and flow metadata if available
         # to determine if this flow is running on the cloud
@@ -145,7 +146,6 @@ def remote(
         task_name = get_from_prefect_context("task_run", "LOCAL")
 
         via_cloud = is_prefect_cloud_deployment()  # always True in tests if set via the method
-        via_cloud = False
         prefect_logger.info(f"Via cloud? {via_cloud}")
 
         # create a new wrapped partial function with the passed *args and **kwargs
@@ -154,8 +154,6 @@ def remote(
 
         # if running a flow locally ignore the remote resource, even if specified
         # necessary for running a @remote decorated task in a local flow
-        print(f"Via cloud? {via_cloud}")
-        print(f"no_resource_on_local variable value: {no_resource_on_local}")
         if not via_cloud and no_resource_on_local:
             resource = None
 

--- a/block_cascade/decorators.py
+++ b/block_cascade/decorators.py
@@ -32,7 +32,7 @@ def remote(
     web_console_access: Optional[bool] = False,
     tune: Optional[Tune] = None,
     code_package: Optional[Path] = None,
-    no_resource_on_local: bool = False,
+    remote_resource_on_local: bool = True,
     *args,
     **kwargs,
 ):
@@ -82,8 +82,11 @@ def remote(
             - The function is not being executed from a Prefect2 Cloud Deployment
             - The function references a module that is not from a third party
             dependency, but from the same package the function is a member of.
-    no_resource_on_local: bool
-        If true, set resource to None when running a Prefect flow locally
+    remote_resource_on_local: bool
+        When running a Prefect flow locally:
+            - If True: use specified remote resource (GCPResource requires an Image URI)
+            - If False: set remote resource to None and fallback to LocalExecutor
+        If the flow is running the Prefect Cloud, this argument will have no effect, regardless of the value.
     """
     if not resource:
         resource_configurations = find_default_configuration() or {}
@@ -109,7 +112,7 @@ def remote(
             resource=resource,
             tune=tune,
             code_package=code_package,
-            no_resource_on_local=no_resource_on_local,
+            remote_resource_on_local=remote_resource_on_local,
             *args,
             **kwargs,
         )
@@ -134,7 +137,7 @@ def remote(
         tune = remote_args.get("tune", None)
         code_package = remote_args.get("code_package", None)
         web_console_access = remote_args.get("web_console_access", False)
-        no_resource_on_local = remote_args.get('no_resource_on_local', False)
+        remote_resource_on_local = remote_args.get('remote_resource_on_local', True)
 
         # get the prefect logger and flow metadata if available
         # to determine if this flow is running on the cloud
@@ -154,8 +157,8 @@ def remote(
 
         # if running a flow locally ignore the remote resource, even if specified
         # necessary for running a @remote decorated task in a local flow
-        if not via_cloud and no_resource_on_local:
-            prefect_logger.info("Not running in Prefect Cloud and no_resource_on_local=True."
+        if not via_cloud and not remote_resource_on_local:
+            prefect_logger.info("Not running in Prefect Cloud and remote_resource_on_local=False."
                                 "Because of this Cascade remote resource set to None and LocalExecutor is used.")
             resource = None
 

--- a/block_cascade/decorators.py
+++ b/block_cascade/decorators.py
@@ -155,6 +155,8 @@ def remote(
         # if running a flow locally ignore the remote resource, even if specified
         # necessary for running a @remote decorated task in a local flow
         if not via_cloud and no_resource_on_local:
+            prefect_logger.info("Not running in Prefect Cloud and no_resource_on_local=True."
+                                "Because of this Cascade remote resource set to None and LocalExecutor is used.")
             resource = None
 
         # if no resource is passed, run locally

--- a/block_cascade/decorators.py
+++ b/block_cascade/decorators.py
@@ -82,6 +82,8 @@ def remote(
             - The function is not being executed from a Prefect2 Cloud Deployment
             - The function references a module that is not from a third party
             dependency, but from the same package the function is a member of.
+    no_resource_on_local: bool
+        If true, set resource to None when running a Prefect flow locally
     """
 
     if not resource:
@@ -142,7 +144,8 @@ def remote(
         task_id = get_from_prefect_context("task_run_id", "LOCAL")
         task_name = get_from_prefect_context("task_run", "LOCAL")
 
-        via_cloud = is_prefect_cloud_deployment()
+        via_cloud = is_prefect_cloud_deployment()  # always True in tests if set via the method
+        via_cloud = False
         prefect_logger.info(f"Via cloud? {via_cloud}")
 
         # create a new wrapped partial function with the passed *args and **kwargs
@@ -151,6 +154,8 @@ def remote(
 
         # if running a flow locally ignore the remote resource, even if specified
         # necessary for running a @remote decorated task in a local flow
+        print(f"Via cloud? {via_cloud}")
+        print(f"no_resource_on_local variable value: {no_resource_on_local}")
         if not via_cloud and no_resource_on_local:
             resource = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "block-cascade"
 packages = [
     {include = "block_cascade"}
 ]
-version = "2.6.1"
+version = "2.6.2"
 description = "Library for model training in multi-cloud environment."
 readme = "README.md"
 authors = ["Block"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "block-cascade"
 packages = [
     {include = "block_cascade"}
 ]
-version = "2.6.0"
+version = "2.6.1"
 description = "Library for model training in multi-cloud environment."
 readme = "README.md"
 authors = ["Block"]

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -7,6 +7,7 @@ import pytest
 from block_cascade import GcpEnvironmentConfig, GcpMachineConfig, GcpResource
 from block_cascade import remote
 from block_cascade.utils import PREFECT_VERSION
+from tests.test_config import gcp_resource
 
 if PREFECT_VERSION == 2:
     from prefect.context import FlowRunContext, TaskRunContext
@@ -39,6 +40,24 @@ def test_remote():
     """Test the remote decorator with the local executor."""
 
     @remote
+    def addition(a: int, b: int) -> int:
+        return a + b
+
+    result = addition(1, 2)
+
+    assert result == 3
+
+
+def test_remote_local_override():
+    """Test the remote decorator with the local executor using the no_resource_on_local flag."""
+    machine_config = GcpMachineConfig(type="n1-standard-4")
+    gcp_resource = GcpResource(
+        chief=machine_config,
+        environment=GcpEnvironmentConfig(
+            storage_location=GCP_STORAGE_LOCATION, project=GCP_PROJECT
+        ),
+    )
+    @remote(resource=gcp_resource, no_resource_on_local=True)
     def addition(a: int, b: int) -> int:
         return a + b
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from unittest.mock import Mock
 
 import pytest
@@ -7,8 +6,6 @@ import pytest
 from block_cascade import GcpEnvironmentConfig, GcpMachineConfig, GcpResource
 from block_cascade import remote
 from block_cascade.utils import PREFECT_VERSION
-from tests.test_config import gcp_resource
-
 if PREFECT_VERSION == 2:
     from prefect.context import FlowRunContext, TaskRunContext
 
@@ -40,24 +37,6 @@ def test_remote():
     """Test the remote decorator with the local executor."""
 
     @remote
-    def addition(a: int, b: int) -> int:
-        return a + b
-
-    result = addition(1, 2)
-
-    assert result == 3
-
-
-def test_remote_local_override():
-    """Test the remote decorator with the local executor using the no_resource_on_local flag."""
-    machine_config = GcpMachineConfig(type="n1-standard-4")
-    gcp_resource = GcpResource(
-        chief=machine_config,
-        environment=GcpEnvironmentConfig(
-            storage_location=GCP_STORAGE_LOCATION, project=GCP_PROJECT
-        ),
-    )
-    @remote(resource=gcp_resource, no_resource_on_local=True)
     def addition(a: int, b: int) -> int:
         return a + b
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -6,6 +6,7 @@ import pytest
 from block_cascade import GcpEnvironmentConfig, GcpMachineConfig, GcpResource
 from block_cascade import remote
 from block_cascade.utils import PREFECT_VERSION
+
 if PREFECT_VERSION == 2:
     from prefect.context import FlowRunContext, TaskRunContext
 

--- a/tests/test_remote_no_prefect.py
+++ b/tests/test_remote_no_prefect.py
@@ -1,0 +1,24 @@
+from block_cascade import GcpEnvironmentConfig, GcpMachineConfig, GcpResource
+from block_cascade import remote
+
+GCP_PROJECT = "test-project"
+GCP_STORAGE_LOCATION = f"gs://{GCP_PROJECT}-cascade/"
+
+
+def test_remote_local_override():
+    """Test the remote decorator with the local executor using the no_resource_on_local flag."""
+    machine_config = GcpMachineConfig(type="n1-standard-4")
+    gcp_resource = GcpResource(
+        chief=machine_config,
+        environment=GcpEnvironmentConfig(
+            storage_location=GCP_STORAGE_LOCATION, project=GCP_PROJECT
+        ),
+    )
+
+    @remote(resource=gcp_resource, no_resource_on_local=True)
+    def multiply(a: int, b: int) -> int:
+        return a * b
+
+    result = multiply(1, 2)
+
+    assert result == 2

--- a/tests/test_remote_no_prefect.py
+++ b/tests/test_remote_no_prefect.py
@@ -15,7 +15,7 @@ def test_remote_local_override():
         ),
     )
 
-    @remote(resource=gcp_resource, no_resource_on_local=True)
+    @remote(resource=gcp_resource, remote_resource_on_local=False)
     def multiply(a: int, b: int) -> int:
         return a * b
 


### PR DESCRIPTION
Goal: Allow for a Prefect task decorated with `@remote` to be able to run both locally and in the Cloud without changing the code or remote args.

Prefect 2 tasks decorated with `@remote` will fail if a resource is set but the flow is run locally:
```
>>> @task(name="test_task")
... @remote(resource=ns8_gcp_resource)
... def test_cascade_task():
...     a = 1
...     b = 3
...     return a + b
...
>>> @flow
... def main_flow():
...     cascade_output = test_cascade_task()
... main_flow(return_state=True)
  File "/Users/tzupan/Development/sq-mml-modeling/.venv/lib/python3.9/site-packages/block_cascade/decorators.py", line 208, in remote_func
    raise RuntimeError(
RuntimeError: Unable to infer remaining environment for GcpResource. Please provide a complete environment to the configured GcpResource.
14:56:17.302 | ERROR   | Flow run 'yellow-civet' - Finished in state Failed('Flow run encountered an exception. RuntimeError: Unable to infer remaining environment for GcpResource. Please provide a complete environment to the configured GcpResource.')
```
Additionally, because of the way Prefect 2+ creates tasks, using `remote_resource` does not solve this problem:
```
>>> @task(name="test_task")
... @remote(resource=ns8_gcp_resource)
... def test_cascade_task(remote_resource):
...     a = 1
...     b = 3
...     return a + b
...
>>> @flow
... def main_flow():
...     cascade_output = test_cascade_task(remote_resource=None)
... main_flow(return_state=True)
  File "/Users/tzupan/Development/sq-mml-modeling/.venv/lib/python3.9/site-packages/block_cascade/decorators.py", line 208, in remote_func
    raise RuntimeError(
RuntimeError: Unable to infer remaining environment for GcpResource. Please provide a complete environment to the configured GcpResource.
14:56:17.302 | ERROR   | Flow run 'yellow-civet' - Finished in state Failed('Flow run encountered an exception. RuntimeError: Unable to infer remaining environment for GcpResource. Please provide a complete environment to the configured GcpResource.')
```
This PR allows for an optional `no_resource_on_local` argument which enables a Cascade decorated task to overwritte the resource to `None` if the flow is being run locally AND the arg is set to True:
```
>>> @task(name="test_task")
... @remote(resource=ns8_gcp_resource, no_resource_on_local=True)
... def test_cascade_task():
...     a = 1
...     b = 3
...     return a + b
...
>>> @flow
... def main_flow():
...     cascade_output = test_cascade_task()
...
>>> main_flow(return_state=True)
16:13:08.342 | INFO    | prefect.engine - Created flow run 'impetuous-gorilla' for flow 'main-flow'
16:13:08.344 | INFO    | Flow run 'impetuous-gorilla' - View at https://app.prefect.cloud/account/74ac256a-9115-4944-9aae-0e14d67fec00/workspace/a60bc68c-d550-411f-9149-c952c21858d1/flow-runs/flow-run/d9443599-77a4-4997-926b-a74ad708308a

16:13:08.765 | INFO    | Flow run 'impetuous-gorilla' - Created task run 'test_task-0' for task 'test_task'
16:13:08.768 | INFO    | Flow run 'impetuous-gorilla' - Executing 'test_task-0' immediately...
16:13:09.085 | INFO    | Task run 'test_task-0' - Via cloud? False
16:13:09.086 | INFO    | Task run 'test_task-0' - Executing task with LocalExecutor.
16:13:09.228 | INFO    | Task run 'test_task-0' - Finished in state Completed()
16:13:09.375 | INFO    | Flow run 'impetuous-gorilla' - Finished in state Completed('All states completed.')
Completed(message='All states completed.', type=COMPLETED, result=UnpersistedResult(type='unpersisted', artifact_type='result', artifact_description='Unpersisted result of type `list`'))
```