### PR TITLE
use runtime.deployment.id to support prefect2 subflows

### DIFF
--- a/block_cascade/decorators.py
+++ b/block_cascade/decorators.py
@@ -219,8 +219,13 @@ def remote(
                     )
 
                 if not resource.environment.is_complete:
+                    missing_env_attributes = [
+                        attr for attr in ["project", "service_account", "region", "image"]
+                        if getattr(resource.environment, attr) is None
+                    ]
                     raise RuntimeError(
                         "Unable to infer remaining environment for GcpResource. "
+                        f"Missing attributes: {missing_env_attributes}. "
                         "Please provide a complete environment to the "
                         "configured GcpResource."
                     )

--- a/block_cascade/prefect/v2/environment.py
+++ b/block_cascade/prefect/v2/environment.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional
 
-from prefect.context import FlowRunContext
+from prefect import runtime
 
 from block_cascade.concurrency import run_async
 from block_cascade.gcp import VertexAIEnvironmentInfoProvider
@@ -102,16 +102,12 @@ class PrefectEnvironmentClient(VertexAIEnvironmentInfoProvider):
         return self._current_infrastructure
 
     def _get_current_deployment(self) -> Optional[DeploymentResponse]:
-        flow_context = FlowRunContext.get()
-        if (
-            not flow_context
-            or not flow_context.flow_run
-            or not flow_context.flow_run.deployment_id
-        ):
+        deployment_id = runtime.deployment.id
+        if not deployment_id:
             return None
 
         if not self._current_deployment:
             self._current_deployment = run_async(
-                _fetch_deployment(flow_context.flow_run.deployment_id)
+                _fetch_deployment(deployment_id)
             )
         return self._current_deployment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "block-cascade"
 packages = [
     {include = "block_cascade"}
 ]
-version = "2.6.2"
+version = "2.6.4"
 description = "Library for model training in multi-cloud environment."
 readme = "README.md"
 authors = ["Block"]

--- a/tests/test_prefect_environment.py
+++ b/tests/test_prefect_environment.py
@@ -2,7 +2,6 @@ import pytest
 from unittest.mock import Mock, patch
 
 from prefect.client.schemas.responses import DeploymentResponse
-from prefect.context import FlowRunContext
 
 from block_cascade.prefect.v2.environment import PrefectEnvironmentClient
 
@@ -43,39 +42,28 @@ def mock__fetch_deployment(mock_deployment_response):
         yield
 
 @pytest.fixture(autouse=True)
-def mock_flow_run_context():
-    mock_flow_run = Mock()
-    mock_flow_run.deployment_id = "mock_deployment_id"
-
-    mock_context = Mock(spec=FlowRunContext)
-    mock_context.flow_run = mock_flow_run
-
-    with patch("block_cascade.prefect.v2.environment.FlowRunContext.get", return_value=mock_context):
-        yield mock_context
+def mock_deployment_id():
+    with patch("prefect.runtime.deployment.id", "mock_deployment_id"):
+        yield
 
 def test_get_container_image():
     client = PrefectEnvironmentClient()
-
     assert client.get_container_image() == "job_image"
 
 def test_get_network():
     client = PrefectEnvironmentClient()
-
     assert client.get_network() == "job_network"
 
 def test_get_project():
     client = PrefectEnvironmentClient()
-
     assert client.get_project() == "job_project"
 
 def test_get_region():
     client = PrefectEnvironmentClient()
-
     assert client.get_region() == "job_region"
 
 def test_get_service_account():
     client = PrefectEnvironmentClient()
-
     assert client.get_service_account() == "job_service_account"
 
 def test_fallback_to_infrastructure(mock_deployment_response):


### PR DESCRIPTION
The `cascade.remote` GCP decorator was giving an error for tasks running within subflows in prefect2 cloud deployments. 
```
404 Client Error: Not Found for url: http://metadata.google.internal/computeMetadata/v1/instance/attributes/?recursive=True
```
This is due to `is_prefect_cloud_deployment` checking for a non-null deployment id by inspecting the flow run context via `FlowRunContext.get().flow_run.deployment_id`, but within a subflow the flow context has `deployment_id=None`, so cascade thinks we are not in a deployment (as seen in `Via cloud? False` logs for the cascade task).

On the other hand, `runtime.deployment.id` consistently gets the same non-null id from the main flow even when running in subflows, so this PR should fix that.

The [prefect2 docs](https://docs-2.prefect.io/latest/guides/runtime-context) are not clear about what happens to the context in subflows, but this minimal example shows the different behavior of `flow_run_context.flow_run.deployment_id` vs `runtime.deployment.id` between flows and subflows:
```python
from prefect import flow, task
from prefect.context import get_run_context
from prefect import runtime

def log_flow_run_context():
    flow_run_ctx = get_run_context()
    print(f"Flow run_context: {flow_run_ctx}")
    print(f"Flow run_context deployment_id: {flow_run_ctx.flow_run.deployment_id}")
    print(f"Runtime deployment ID {runtime.deployment.id}")


@flow(log_prints=True)
def sub_flow():
    log_flow_run_context()
    # cascade.remote tasks would succeed if current flow is running as main flow, and fail if running as subflow


@flow(log_prints=True)
def main_flow():
    log_flow_run_context()
    sub_flow()
```


TODO:
- [x]  bump version