### PR TITLE
try to fix local tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+import os
+import shutil
+import pytest
+from pyfakefs.fake_filesystem_unittest import Patcher
+
+@pytest.fixture(autouse=True)
+def fs():
+    """Create a fake filesystem."""
+    patcher = Patcher(
+        modules_to_reload=[],
+        # Skip patching any torch modules that try to access os
+        additional_skip_names=[
+            "torch._functorch.config",
+            "torch._inductor.config",
+            "torch.fx.experimental._config",
+            "torch._dynamo.config",
+            "torch",
+        ]
+    )
+    patcher.setUp()
+    
+    # Create the site-packages directory structure first
+    site_packages_path = '/Users/angelo/Development/cascade/.venv/lib/python3.9/site-packages'
+    os.makedirs(site_packages_path, exist_ok=True)
+    
+    # Create package metadata for block_cascade
+    dist_info_path = os.path.join(site_packages_path, 'block_cascade-2.6.2.dist-info')
+    os.makedirs(dist_info_path, exist_ok=True)
+    metadata_path = os.path.join(dist_info_path, 'METADATA')
+    patcher.fs.create_file(metadata_path, contents="""Metadata-Version: 2.1
+Name: block-cascade
+Version: 2.6.2
+Summary: Block Cascade
+Author: Test Author
+Author-email: test@example.com
+Requires-Python: >=3.9
+""")
+    
+    # Add the torch directory as a real directory
+    patcher.fs.add_real_directory(os.path.join(site_packages_path, 'torch'))
+    
+    # Create temp directory structure
+    tmp_path = '/var/folders/lt/6znk4r891xdcrhm2s2cjlzk40000gn/T/pytest-of-angelo'
+    if os.path.exists(tmp_path):
+        shutil.rmtree(tmp_path)
+    os.makedirs(tmp_path, exist_ok=True)
+    os.chmod(tmp_path, 0o700)
+    
+    # Create numbered temp directories
+    for i in range(10):
+        numbered_dir = os.path.join(tmp_path, f'pytest-{i}')
+        os.makedirs(numbered_dir, exist_ok=True)
+        os.chmod(numbered_dir, 0o700)
+    
+    # Create current symlink
+    current_link = os.path.join(tmp_path, 'pytest-current')
+    if os.path.exists(current_link):
+        os.unlink(current_link)
+    os.symlink(os.path.join(tmp_path, 'pytest-0'), current_link)
+    
+    yield patcher.fs
+    patcher.tearDown()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,9 +16,15 @@ GCP_PROJECT = "test-project"
 GCP_STORAGE_LOCATION = f"gs://{GCP_PROJECT}-cascade/"
 
 
+@pytest.fixture(autouse=True)
+def clean_fs(fs):
+    # Reset the filesystem before each test
+    fs.reset()
+
+
 @pytest.fixture(params=["cascade.yaml", "cascade.yml"])
 def configuration_filename(request):
-    return request.param
+    return f"./{request.param}"
 
 
 @pytest.fixture()
@@ -75,7 +81,7 @@ def test_job_name():
     return "hello-world"
 
 
-def test_no_configuration():
+def test_no_configuration(fs):
     assert find_default_configuration() is None
 
 


### PR DESCRIPTION
Local tests fail on main:
```
============================================================================ short test summary info ============================================================================
FAILED tests/test_config.py::test_invalid_type_specified[cascade.yml] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED tests/test_config.py::test_gcp_resource[cascade.yaml] - TypeError: 'NoneType' object is not subscriptable
FAILED tests/test_config.py::test_gcp_resource[cascade.yml] - FileExistsError: [Errno 17] File exists in the fake filesystem: '/cascade.yml'
FAILED tests/test_config.py::test_databricks_resource[cascade.yaml] - FileExistsError: [Errno 17] File exists in the fake filesystem: '/cascade.yaml'
FAILED tests/test_config.py::test_databricks_resource[cascade.yml] - FileExistsError: [Errno 17] File exists in the fake filesystem: '/cascade.yml'
FAILED tests/test_config.py::test_merged_resources[cascade.yaml] - FileExistsError: [Errno 17] File exists in the fake filesystem: '/cascade.yaml'
FAILED tests/test_config.py::test_merged_resources[cascade.yml] - FileExistsError: [Errno 17] File exists in the fake filesystem: '/cascade.yml'
FAILED tests/test_torch.py::test_torchjob - FileNotFoundError: https://storage.googleapis.com/upload/storage/v1/b/ds-cash-production-cascade/o
ERROR tests/test_config.py::test_invalid_type_specified[cascade.yaml] - AttributeError: torch._inductor.config.os does not exist
```

Haven't had time to dig much into it but it looks like it's due to different tests filesystem fixtures interacting with each other. After a letting goose got at it for a while I got it down to only error in `test_torch.py`:
```
============================================================================ short test summary info ============================================================================
FAILED tests/test_torch.py::test_torchjob - ModuleNotFoundError: No module named 'block_cascade.executors.vertex.executor.GcpExecutor'; 'block_cascade.executors.vertex.executor' is not a package
ERROR tests/test_vertex_executor.py::test_stage - OSError: could not create numbered dir with prefix pytest- in /var/folders/lt/6znk4r891xdcrhm2s2cjlzk40000gn/T/pytest-of-angelo after 10 tries
=============================================================== 1 failed, 35 passed, 3 warnings, 1 error in 5.72s ===============================================================
```