### PR TITLE
Add a Typed Data Model to Specify Python Packages

### DIFF
--- a/block_cascade/executors/databricks/job.py
+++ b/block_cascade/executors/databricks/job.py
@@ -1,11 +1,12 @@
 """ Data model for task running on Databricks
 """
 from importlib.metadata import version
-from typing import Optional
+from typing import Any, Optional
 
 from block_cascade.executors.databricks.resource import (
     DatabricksAutoscaleConfig,
     DatabricksResource,
+    PythonLibrary
 )
 
 from pydantic import BaseModel
@@ -86,32 +87,17 @@ class DatabricksJob(BaseModel):
             **task_args,
         }
 
-    def _libraries(self):
-        libraries_to_add = []
-
-        python_libraries = self.resource.python_libraries or []
-
-        if "cloudpickle" not in python_libraries:
-            python_libraries.append("cloudpickle")
-        if "prefect" not in python_libraries:
-            python_libraries.append("prefect")
-
-        for package_name in python_libraries:
-            # if the resource construction specifies a version, use that,
-            # otherwise use the version from the environment
-            if "==" in package_name:
-                package = package_name
-            else:
-                package = f"{package_name}=={version(package_name)}"
-            libraries_to_add.append(
-                {
-                    "pypi": {
-                        "package": package,
-                        "repo": ARTIFACTORY,
-                    }
-                }
+    def _libraries(self) -> list[dict[str, Any]]:
+        required_libraries = ("cloudpickle", "prefect")
+        for lib in required_libraries:
+            if any(lib == package.name for package in self.resource.python_libraries):
+                continue
+            self.resource.python_libraries.append(
+                PythonLibrary(
+                    name=lib
+                )
             )
-        return libraries_to_add
+        return [package.model_dump() for package in self.resource.python_libraries]
 
     def _cluster_spec(self):
         """

--- a/block_cascade/executors/databricks/job.py
+++ b/block_cascade/executors/databricks/job.py
@@ -6,12 +6,10 @@ from typing import Any, Optional
 from block_cascade.executors.databricks.resource import (
     DatabricksAutoscaleConfig,
     DatabricksResource,
-    PythonLibrary
+    DatabricksPythonLibrary
 )
 
 from pydantic import BaseModel
-
-ARTIFACTORY = "https://artifactory.global.square/artifactory/api/pypi/block-pypi/simple"
 
 
 class DatabricksJob(BaseModel):
@@ -93,7 +91,7 @@ class DatabricksJob(BaseModel):
             if any(lib == package.name for package in self.resource.python_libraries):
                 continue
             self.resource.python_libraries.append(
-                PythonLibrary(
+                DatabricksPythonLibrary(
                     name=lib
                 )
             )

--- a/block_cascade/executors/databricks/resource.py
+++ b/block_cascade/executors/databricks/resource.py
@@ -1,8 +1,12 @@
+import importlib.metadata
+import logging
 import os
-from typing import List, Optional, Union
+from typing import Any, Iterator, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
+
+logger = logging.getLogger(__name__)
 
 class DatabricksSecret(BaseModel):
     """Databricks secret to auth to Databricks
@@ -33,6 +37,53 @@ class DatabricksAutoscaleConfig(BaseModel):
     max_workers: int = 8
 
 
+class PythonLibrary(BaseModel):
+    """Configuration for a Python library to be installed on a Databricks cluster.
+    
+    Reference: https://docs.databricks.com/aws/en/reference/jobs-2.0-api#pythonpypilibrary
+
+    Parameters
+    ----------
+    name: str
+        The name of the package.
+    repo: Optional[str]
+        The Python package index to install the package from. If not specified,
+        defaults to the configured package index on the Databricks cluster which
+        is most likely PyPI.
+    version: Optional[str]
+        The version of the package.
+    infer_version: bool
+        Whether to infer the version of the package from the current
+        environment if not specified.
+    """
+    name: str
+    repo: Optional[str] = None
+    version: Optional[str] = None
+    infer_version: bool = True
+
+    @model_validator(mode="after")
+    def maybe_update_version(self):
+        if self.infer_version and not self.version:
+            try:
+                self.version = importlib.metadata.version(self.name)
+            except importlib.metadata.PackageNotFoundError:
+                logger.warning(
+                    f"Could not infer version for package '{self.name}' from runtime. "
+                    "The version will be left unspecified for Databricks runtime "
+                    "installation."
+                )
+        return self
+
+    def model_dump(self, **kwargs) -> dict:
+        package_specififer = f"{self.name}=={self.version}" if self.version else self.name
+        return {
+            "pypi": {
+                "package": package_specififer,
+                **({"repo": self.repo} if self.repo else {})
+            }
+        }
+
+
 class DatabricksResource(BaseModel):
     """Description of a Databricks Cluster
 
@@ -41,14 +92,14 @@ class DatabricksResource(BaseModel):
     storage_location: str
        Path to the directory on s3 where files will be staged and output written
        cascade needs to have access to this bucket from the execution environment
-    worker_count: Optional[Union[int, DatabricksAutoscaleConfig]]
+    worker_count: Union[int, DatabricksAutoscaleConfig]
         If an integer is supplied, specifies the of workers in Databricks cluster.
         If a `DatabricksAutoscaleConfig` is supplied, specifies the autoscale
-        configuration to use. Default is 1 worker, not autoscaling.
-    machine: Optional[str]
+        configuration to use. Default is 1 worker without autoscaling enabled.
+    machine: str
         AWS machine type for worker nodes. See https://www.databricks.com/product/aws-pricing/instance-types
         Default is i3.xlarge (4 vCPUs, 31 GB RAM)
-    spark_version: Optional[str]
+    spark_version: str
         Databricks runtime version. Tested on 11.3.x-scala2.12.
         https://docs.databricks.com/release-notes/runtime/releases.html
         Default is 11.3.x-scala2.12
@@ -86,24 +137,24 @@ class DatabricksResource(BaseModel):
         For details see: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
     cloud_pickle_by_value: list[str]
         List of names of modules to be pickled by value instead of by reference.
-    cloudpickle_infer_base_module: Optional[bool] = True
+    cloudpickle_infer_base_module: bool = True
         Whether to automatically infer the remote function's base module to be included
         in the `cloudpickle_by_value`
     task_args: Optional[dict] = None
         If provided, pass these additional arguments into the databricks task. This can
         be used
-    python_libraries: Optional[List[str]] = None
+    python_libraries: List[PythonLibrary] = [] 
         If provided, install these additional libraries on the cluster when the
-        remote task is run
+        remote task is run.
     timeout_seconds: int = 86400
         The maximum time this job can run for; default is 24 hours.
 
     """  # noqa: E501
 
     storage_location: str
-    worker_count: Optional[Union[int, DatabricksAutoscaleConfig]] = 1
-    machine: Optional[str] = "i3.xlarge"
-    spark_version: Optional[str] = "11.3.x-scala2.12"
+    worker_count: Union[int, DatabricksAutoscaleConfig] = 1
+    machine: str = "i3.xlarge"
+    spark_version: str = "11.3.x-scala2.12"
     data_security_mode: Optional[str] = "SINGLE_USER"
     cluster_spec_overrides: Optional[dict] = None
     cluster_policy: Optional[str] = None
@@ -112,8 +163,8 @@ class DatabricksResource(BaseModel):
     secret: Optional[DatabricksSecret] = None
     environment: Optional[str] = "prod"
     s3_credentials: Optional[dict] = None
-    cloud_pickle_by_value: Optional[List[str]] = Field(default_factory=list)
-    cloud_pickle_infer_base_module: Optional[bool] = True
+    cloud_pickle_by_value: List[str] = Field(default_factory=list)
+    cloud_pickle_infer_base_module: bool = True
     task_args: Optional[dict] = None
-    python_libraries: Optional[List[str]] = None
+    python_libraries: list[PythonLibrary] = Field(default_factory=list)
     timeout_seconds: int = 86400

--- a/block_cascade/executors/databricks/resource.py
+++ b/block_cascade/executors/databricks/resource.py
@@ -37,7 +37,7 @@ class DatabricksAutoscaleConfig(BaseModel):
     max_workers: int = 8
 
 
-class PythonLibrary(BaseModel):
+class DatabricksPythonLibrary(BaseModel):
     """Configuration for a Python library to be installed on a Databricks cluster.
     
     Reference: https://docs.databricks.com/aws/en/reference/jobs-2.0-api#pythonpypilibrary
@@ -166,5 +166,5 @@ class DatabricksResource(BaseModel):
     cloud_pickle_by_value: List[str] = Field(default_factory=list)
     cloud_pickle_infer_base_module: bool = True
     task_args: Optional[dict] = None
-    python_libraries: list[PythonLibrary] = Field(default_factory=list)
+    python_libraries: list[DatabricksPythonLibrary] = Field(default_factory=list)
     timeout_seconds: int = 86400

--- a/block_cascade/executors/databricks/resource.py
+++ b/block_cascade/executors/databricks/resource.py
@@ -54,7 +54,12 @@ class DatabricksPythonLibrary(BaseModel):
         The version of the package.
     infer_version: bool
         Whether to infer the version of the package from the current
-        environment if not specified.
+        environment if not specified explicitly. Defaults to True.
+        It is critical to recognize the Databricks runtime has preinstalled
+        packages so version pinning can lead to an incompatible Databricks
+        runtime.  Alternatively by not pinning, an incompatible version
+        of the dependency could be installed that is not compatible with
+        your code.
     """
     name: str
     repo: Optional[str] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "block-cascade"
 packages = [
     {include = "block_cascade"}
 ]
-version = "2.9.0"
+version = "2.10.0"
 description = "Library for model training in multi-cloud environment."
 readme = "README.md"
 authors = ["Block"]

--- a/tests/executors/databricks/resource/test_python_library.py
+++ b/tests/executors/databricks/resource/test_python_library.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
-from block_cascade.executors.databricks.resource import PythonLibrary
+from block_cascade.executors.databricks.resource import DatabricksPythonLibrary
 
 
 def test_python_library_model_dump():
-    library = PythonLibrary(name="example-package", version="1.2.3", repo="https://example.com/pypi")
+    library = DatabricksPythonLibrary(name="example-package", version="1.2.3", repo="https://example.com/pypi")
     expected_output = {
         "pypi": {
             "package": "example-package==1.2.3",
@@ -12,7 +12,7 @@ def test_python_library_model_dump():
     }
     assert library.model_dump() == expected_output
 
-    library = PythonLibrary(name="example-package", infer_version=False)
+    library = DatabricksPythonLibrary(name="example-package", infer_version=False)
     expected_output = {
         "pypi": {
             "package": "example-package"
@@ -23,5 +23,5 @@ def test_python_library_model_dump():
 def test_python_library_infer_version():
     with patch("block_cascade.executors.databricks.resource.importlib.metadata.version") as mock_version:
         mock_version.return_value = "4.5.6"
-        library = PythonLibrary(name="example-package", infer_version=True)
+        library = DatabricksPythonLibrary(name="example-package", infer_version=True)
         assert library.version == "4.5.6"

--- a/tests/executors/databricks/resource/test_python_library.py
+++ b/tests/executors/databricks/resource/test_python_library.py
@@ -25,3 +25,65 @@ def test_python_library_infer_version():
         mock_version.return_value = "4.5.6"
         library = DatabricksPythonLibrary(name="example-package", infer_version=True)
         assert library.version == "4.5.6"
+
+
+def test_databricks_resource_string_library_conversion():
+    from block_cascade.executors.databricks.resource import DatabricksResource
+    
+    resource = DatabricksResource(
+        storage_location="s3://test-bucket/cascade",
+        python_libraries=["test-package"]
+    )
+    
+    assert len(resource.python_libraries) == 1
+    assert isinstance(resource.python_libraries[0], DatabricksPythonLibrary)
+    assert resource.python_libraries[0].name == "test-package"
+    
+    resource = DatabricksResource(
+        storage_location="s3://test-bucket/cascade",
+        python_libraries=[
+            "package1", 
+            DatabricksPythonLibrary(name="package2", version="1.0.0")
+        ]
+    )
+    
+    assert len(resource.python_libraries) == 2
+    assert isinstance(resource.python_libraries[0], DatabricksPythonLibrary)
+    assert isinstance(resource.python_libraries[1], DatabricksPythonLibrary)
+    assert resource.python_libraries[0].name == "package1"
+    assert resource.python_libraries[1].name == "package2"
+    assert resource.python_libraries[1].version == "1.0.0"
+
+
+def test_databricks_resource_string_with_version_conversion():
+    from block_cascade.executors.databricks.resource import DatabricksResource
+    
+    resource = DatabricksResource(
+        storage_location="s3://test-bucket/cascade",
+        python_libraries=["cloudpickle==0.10.0"]
+    )
+    
+    assert len(resource.python_libraries) == 1
+    assert isinstance(resource.python_libraries[0], DatabricksPythonLibrary)
+    assert resource.python_libraries[0].name == "cloudpickle"
+    assert resource.python_libraries[0].version == "0.10.0"
+    
+    resource = DatabricksResource(
+        storage_location="s3://test-bucket/cascade",
+        python_libraries=[
+            "numpy==1.22.4",
+            "pandas==2.0.0",
+            DatabricksPythonLibrary(name="scikit-learn", version="1.2.2")
+        ]
+    )
+    
+    assert len(resource.python_libraries) == 3
+    assert isinstance(resource.python_libraries[0], DatabricksPythonLibrary)
+    assert isinstance(resource.python_libraries[1], DatabricksPythonLibrary)
+    assert isinstance(resource.python_libraries[2], DatabricksPythonLibrary)
+    assert resource.python_libraries[0].name == "numpy"
+    assert resource.python_libraries[0].version == "1.22.4"
+    assert resource.python_libraries[1].name == "pandas"
+    assert resource.python_libraries[1].version == "2.0.0"
+    assert resource.python_libraries[2].name == "scikit-learn"
+    assert resource.python_libraries[2].version == "1.2.2"

--- a/tests/executors/databricks/resource/test_python_library.py
+++ b/tests/executors/databricks/resource/test_python_library.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+from block_cascade.executors.databricks.resource import PythonLibrary
+
+
+def test_python_library_model_dump():
+    library = PythonLibrary(name="example-package", version="1.2.3", repo="https://example.com/pypi")
+    expected_output = {
+        "pypi": {
+            "package": "example-package==1.2.3",
+            "repo": "https://example.com/pypi"
+        }
+    }
+    assert library.model_dump() == expected_output
+
+    library = PythonLibrary(name="example-package", infer_version=False)
+    expected_output = {
+        "pypi": {
+            "package": "example-package"
+        }
+    }
+    assert library.model_dump() == expected_output
+
+def test_python_library_infer_version():
+    with patch("block_cascade.executors.databricks.resource.importlib.metadata.version") as mock_version:
+        mock_version.return_value = "4.5.6"
+        library = PythonLibrary(name="example-package", infer_version=True)
+        assert library.version == "4.5.6"


### PR DESCRIPTION
This change aims to provided a better interface when specifying Python packages for Databricks tasks which:
- Encapsulates how the model should be converted to a Python dictionary for parameterizing a Databricks API request.
- Parameterizes the package index of a package and removes the internal reference to Block's package index.
- Allows a package to be specified without an exact version

## Previous Behavior
```python
resource = DatabricksResource(
  # provide required args
  python_libraries=["cloudpickle", "prefect==2.20.0"]
)
```

Some problems with this approach are:
- Package index is not configurable (and actually coupled to Block internal package index which should be removed in OSS)
- Opaque that the version of `cloudpickle` will attempt to be inferred from the runtime environment even if the user does not want to pin to a specific version but allow resolution to choose a compatible version

## New Behavior
```python
resource = DatabricksResource(
  # provide required args
  python_libraries = [
    DatabricksPythonLibrary(
      name="cloudpickle",
      infer_version=True
      repo="https://artifactory.global.square/artifactory/api/pypi/block-pypi/simple"
    ),
    DatabricksPythonLibrary(
      name="prefect",
      infer_version=False,
      repo="https://pypi.org/simple/"
    )
  ]
)
```

The problems above are improved by:
- Allowing package index to be configurable
- Allow exact version to not be specified