### PR TITLE
Remove default spark_version from DatabricksResource

### DIFF
--- a/block_cascade/executors/databricks/resource.py
+++ b/block_cascade/executors/databricks/resource.py
@@ -107,7 +107,6 @@ class DatabricksResource(BaseModel):
     spark_version: str
         Databricks runtime version. Tested on 11.3.x-scala2.12.
         https://docs.databricks.com/release-notes/runtime/releases.html
-        Default is 11.3.x-scala2.12
     data_security_mode: Optional[str]
         See `data_security_mode` at
         https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-attribute-paths
@@ -159,7 +158,7 @@ class DatabricksResource(BaseModel):
     storage_location: str
     worker_count: Union[int, DatabricksAutoscaleConfig] = 1
     machine: str = "i3.xlarge"
-    spark_version: str = "11.3.x-scala2.12"
+    spark_version: str
     data_security_mode: Optional[str] = "SINGLE_USER"
     cluster_spec_overrides: Optional[dict] = None
     cluster_policy: Optional[str] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "block-cascade"
 packages = [
     {include = "block_cascade"}
 ]
-version = "2.10.2"
+version = "3.0.0"
 description = "Library for model training in multi-cloud environment."
 readme = "README.md"
 authors = ["Block"]

--- a/tests/executors/databricks/resource/test_python_library.py
+++ b/tests/executors/databricks/resource/test_python_library.py
@@ -32,6 +32,7 @@ def test_databricks_resource_string_library_conversion():
     
     resource = DatabricksResource(
         storage_location="s3://test-bucket/cascade",
+        spark_version="11.3.x-scala2.12",
         python_libraries=["test-package"]
     )
     
@@ -41,8 +42,9 @@ def test_databricks_resource_string_library_conversion():
     
     resource = DatabricksResource(
         storage_location="s3://test-bucket/cascade",
+        spark_version="11.3.x-scala2.12",
         python_libraries=[
-            "package1", 
+            "package1",
             DatabricksPythonLibrary(name="package2", version="1.0.0")
         ]
     )
@@ -60,6 +62,7 @@ def test_databricks_resource_string_with_version_conversion():
     
     resource = DatabricksResource(
         storage_location="s3://test-bucket/cascade",
+        spark_version="11.3.x-scala2.12",
         python_libraries=["cloudpickle==0.10.0"]
     )
     
@@ -70,6 +73,7 @@ def test_databricks_resource_string_with_version_conversion():
     
     resource = DatabricksResource(
         storage_location="s3://test-bucket/cascade",
+        spark_version="11.3.x-scala2.12",
         python_libraries=[
             "numpy==1.22.4",
             "pandas==2.0.0",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,6 +67,7 @@ def databricks_resource():
         storage_location="s3://test-bucket/cascade",
         worker_count=DatabricksAutoscaleConfig(min_workers=5, max_workers=10),
         cloud_pickle_by_value=["a", "b"],
+        spark_version="11.3.x-scala2.12",
     )
 
 
@@ -120,13 +121,14 @@ def test_databricks_resource(
     configuration = f"""
 {test_job_name}:
     type: DatabricksResource
-    storage_location: {databricks_resource.storage_location}    
+    storage_location: {databricks_resource.storage_location}
     worker_count:
         min_workers: {databricks_resource.worker_count.min_workers}
         max_workers: {databricks_resource.worker_count.max_workers}
     cloud_pickle_by_value:
         - a
         - b
+    spark_version: {databricks_resource.spark_version}
 """
     fs.create_file(configuration_filename, contents=configuration)
     assert databricks_resource == find_default_configuration()[test_job_name]

--- a/tests/test_databricks_executor.py
+++ b/tests/test_databricks_executor.py
@@ -19,6 +19,7 @@ DATABRICKS_GROUP = "cascade"
 databricks_resource = DatabricksResource(
     storage_location="s3://test-bucket/cascade",
     group_name=DATABRICKS_GROUP,
+    spark_version="11.3.x-scala2.12",
 )
 
 


### PR DESCRIPTION
## Summary
- Remove the default value for `spark_version` field in `DatabricksResource` (previously defaulted to "11.3.x-scala2.12")
- Update `pyproject.toml` version from 2.10.2 to 3.0.0 to reflect this breaking change
- Update all tests to explicitly provide `spark_version` parameter

## Breaking Change
⚠️ **BREAKING CHANGE**: Users must now explicitly provide `spark_version` when instantiating `DatabricksResource`.

**Before:**
```python
resource = DatabricksResource(
    storage_location="s3://test-bucket/cascade",
    group_name="my-group"
)
```

**After:**
```python
resource = DatabricksResource(
    storage_location="s3://test-bucket/cascade",
    group_name="my-group",
    spark_version="11.3.x-scala2.12"  # Now required
)
```

## Rationale
Removing the default spark version ensures users explicitly choose the Databricks runtime version appropriate for their workload, preventing implicit dependencies on potentially outdated runtime versions.

## Test plan
- [x] All existing tests updated to explicitly provide `spark_version`
- [x] Tests pass: `poetry run pytest tests/executors/databricks/resource/test_python_library.py -v`
- [x] Tests pass: `poetry run pytest tests/test_databricks_executor.py tests/test_config.py::test_databricks_resource -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)