### PR TITLE
Relax cloudpickle constraint

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -648,14 +648,14 @@ files = [
 
 [[package]]
 name = "cloudpickle"
-version = "2.2.1"
-description = "Extended pickling support for Python objects"
+version = "3.1.2"
+description = "Pickler class to extend the standard pickle.Pickler functionality"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "cloudpickle-2.2.1-py3-none-any.whl", hash = "sha256:61f594d1f4c295fa5cd9014ceb3a1fc4a70b0de1164b94fbc2d854ccba056f9f"},
-    {file = "cloudpickle-2.2.1.tar.gz", hash = "sha256:d89684b8de9e34a2a43b3460fbca07d09d6e25ce858df4d5a44240403b6178f5"},
+    {file = "cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a"},
+    {file = "cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -5286,4 +5286,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.13"
-content-hash = "2f0311fb72a37cc4bda65ecb308cdea7d6c9fc4c1a7ef8792b0b68770f888da4"
+content-hash = "8a62dd38d0ef644d62f16783f2fef2b427646a9864eef09f18924276a852c063"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "block-cascade"
 packages = [
     {include = "block_cascade"}
 ]
-version = "3.2.0"
+version = "3.2.1"
 description = "Library for model training in multi-cloud environment."
 readme = "README.md"
 authors = ["Block"]
@@ -11,7 +11,7 @@ authors = ["Block"]
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 cloudml-hypertune = "==0.1.0.dev6"
-cloudpickle = "^2.0"
+cloudpickle = ">=2.0,<4.0"
 databricks-cli = ">=0.17.7"
 gcsfs = ">=2024"
 google-auth = "^2.23.2"


### PR DESCRIPTION
## Why
Prefect 3.6.28+ requires `cloudpickle>=3.1.1`, but block-cascade's existing `^2.0` constraint prevents downstream projects from upgrading Prefect for SCC remediation.

## What
- Relax block-cascade's cloudpickle constraint to `>=2.0,<4.0`
- Bump block-cascade to `3.2.1` for a publishable patch release

## Risk Assessment
Low — this is a dependency metadata change only, and focused executor tests pass with the resolved dependency set.

## References
- FAB-2603
- Tested: `poetry check`
- Tested: `poetry run pytest tests/test_local_executor.py tests/test_vertex_executor.py -q`

---
**Update May 8, 09:20:** Locked and tested cloudpickle 3.1.2.
- Updated `poetry.lock` to resolve `cloudpickle==3.1.2`
- Tested: `poetry run pytest tests/test_local_executor.py tests/test_vertex_executor.py tests/test_databricks_executor.py tests/executors/databricks/resource/test_python_library.py -q`
- Tested after `poetry sync --without torch`: `poetry run pytest -q` (46 passed, 1 skipped)
