### PR TITLE
ci: declare contents:read on Python application workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: '*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Pins `python-app.yml` to `contents: read` at workflow scope. The single matrix job (Python 3.9-3.14) only checks out, installs uv via pipx, runs `uv sync --frozen`, and `uv run pytest`. No GitHub API write, no cache plumbing.

Defense-in-depth motivation is [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) on `tj-actions/changed-files`: a compromised third-party action runs inside the existing job context and exfiltrates the workflow `GITHUB_TOKEN` via build logs.

Style matches the per-job permissions block in `python-publish.yml` (`id-token: write` for trusted publishing). YAML validated locally with `yaml.safe_load`.